### PR TITLE
AT_11.03.02_09 | Educations > Menu item [Day Trading] > Test button [Get it on Google Play] in Block "Sign up and trade smart today!"

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -221,6 +221,7 @@ def init_remote_driver_chrome():
     # chrome_options.add_argument(conf.CHROME_WINDOW_SIZES_4k)
     # Код, отмены информационного сообщения "USB: usb_device_handle_win.cc"
     chrome_options.add_experimental_option('excludeSwitches', ['enable-logging'])
+    chrome_options.add_argument("--accept-lang=en")
 
     # !!!
     # если следующую строку раскомментировать, то Chrome отображаться не будет

--- a/pages/Elements/AssertClass.py
+++ b/pages/Elements/AssertClass.py
@@ -11,6 +11,7 @@ from datetime import datetime
 
 from pages.AppStore.app_store import AppStore
 from pages.Capital.Trading_platform.trading_platform import TradingPlatform
+from pages.GooglePlay.google_play import GooglePlay
 from pages.base_page import BasePage
 from pages.Signup_login.signup_login import SignupLogin
 
@@ -76,6 +77,12 @@ class AssertClass(BasePage):
         print(f"\n{datetime.now()}   3. Assert")
         self.page_app_store = AppStore(d)
         self.page_app_store.should_be_app_store_page(cur_link)
+
+    @allure.step('Checking that "Google Play" page opened')
+    def assert_google_play(self, d, cur_link):
+        print(f"\n{datetime.now()}   3. Assert")
+        self.page_google_play = GooglePlay(d)
+        self.page_google_play.should_be_google_play_page(cur_link)
 
     @allure.step('Checking that "Sign Up" form on the Trading Platform page opened')
     def assert_signup_form_on_the_trading_platform(self, d):

--- a/pages/Elements/ButtonGetItOnGooglePlay.py
+++ b/pages/Elements/ButtonGetItOnGooglePlay.py
@@ -1,0 +1,50 @@
+"""
+-*- coding: utf-8 -*-
+@Time    : 2023/06/22 15:30
+@Author  : Andrey Bozhko
+"""
+from datetime import datetime
+import pytest
+import allure
+from pages.base_page import BasePage
+from selenium.common.exceptions import ElementClickInterceptedException
+from pages.Elements.testing_elements_locators import BlockSignUpAndTradeSmartTodayLocators
+
+
+class ButtonGetItOnGooglePlay(BasePage):
+
+    def arrange_(self, cur_item_link):
+        print(f"\n{datetime.now()}   1. Arrange")
+
+        if not self.current_page_is(cur_item_link):
+            self.link = cur_item_link
+            self.open_page()
+
+        print(f"{datetime.now()}   Is visible BUTTON_GET_IT_ON_GOOGLE_PLAY? =>")
+        if self.element_is_visible(BlockSignUpAndTradeSmartTodayLocators.BUTTON_GET_IT_ON_GOOGLE_PLAY):
+            print(f"{datetime.now()}   => BUTTON_GET_IT_ON_GOOGLE_PLAY is visible on the page!")
+        else:
+            print(f"{datetime.now()}   => BUTTON_GET_IT_ON_GOOGLE_PLAY is not visible on the page!")
+            pytest.skip("Checking element is not on this page")
+
+    @allure.step("Click 'Get it on Google Play' in Block 'Sign up and trade smart today!'")
+    def element_click(self):
+        """Method"""
+        print(f"\n{datetime.now()}   2. Act")
+        button_list = self.browser.find_elements(*BlockSignUpAndTradeSmartTodayLocators.BUTTON_GET_IT_ON_GOOGLE_PLAY)
+        if len(button_list) == 0:
+            return False
+        print(f"{datetime.now()}   "
+              f"{len(button_list)} checking element(s) with current CSS locator is(are) present(s) on this page")
+        self.browser.execute_script(
+            'return arguments[0].scrollIntoView({block: "center", inline: "nearest"});',
+            button_list[0]
+        )
+        self.element_is_clickable(button_list[0], 10)
+        try:
+            button_list[0].click()
+            print(f"{datetime.now()}   => BUTTON_GET_IT_ON_GOOGLE_PLAY IS CLICKED")
+        except ElementClickInterceptedException:
+            print(f"{datetime.now()}   => BUTTON_GET_IT_ON_GOOGLE_PLAY IS NOT CLICKED")
+        return True
+

--- a/pages/Elements/testing_elements_locators.py
+++ b/pages/Elements/testing_elements_locators.py
@@ -118,6 +118,7 @@ class RightBannerLocators:
 
 class BlockSignUpAndTradeSmartTodayLocators:
     BUTTON_DOWNLOAD_APP_STORE = (By.CSS_SELECTOR, "div.banner-capital__buttons a[data-type='banner_capital_ios']")
+    BUTTON_GET_IT_ON_GOOGLE_PLAY = (By.CSS_SELECTOR, "div.banner-capital__buttons a[data-type='banner_capital_google']")
     BUTTON_EXPLORE_WEB_PLATFORM = (
         By.CSS_SELECTOR, "div.banner-capital__buttons a[data-type='banner_capital_platform']")
 

--- a/pages/GooglePlay/google_play.py
+++ b/pages/GooglePlay/google_play.py
@@ -1,0 +1,41 @@
+"""
+-*- coding: utf-8 -*-
+@Time    : 2023/06/20 11:00
+@Author  : Andrey Bozhko
+"""
+
+import allure
+from datetime import datetime
+from pages.base_page import BasePage
+from pages.GooglePlay.google_play_locators import GooglePlayLocators
+from test_data.google_play_data import *
+
+
+class GooglePlay(BasePage):
+    @allure.step("Checking that the Google Play page has opened")
+    def should_be_google_play_page(self, cur_link):
+        """Check if the page is open"""
+        print(f"{datetime.now()}   Checking that the Google Play page has opened")
+        self.wait_for_change_url(cur_link, 10)
+        # Следующие две строки только для проверки работоспособности asserts, тк в данный момент баг в url кнопки
+        # self.link = "https://play.google.com/store/apps/details?id=com.capital.trading"
+        # self.open_page()
+        if self.current_page_url_contain_the(data["APP_URL"]):
+            self.should_be_page_title_v2(data["PAGE_TITLE"])
+            self.should_be_google_play_app_title(data["APP_TITLE"])
+            self.should_be_google_play_specifies_provider(data["PROVIDER"])
+            assert True
+        else:
+            assert False, f'Loaded page with not {data["APP_URL"]} url'
+
+    @allure.step("Checking that the Google Play app title")
+    def should_be_google_play_app_title(self, app_title):
+        """Check if the app title"""
+        print(f"{datetime.now()}   Checking that the Google Play app title")
+        assert self.get_text(0, *GooglePlayLocators.APP_TITLE) == app_title
+
+    @allure.step("Checking that the Google Play specifies provider")
+    def should_be_google_play_specifies_provider(self, provider):
+        """Check if the specifies provider"""
+        print(f"{datetime.now()}   Checking that the App Store specifies provider")
+        assert self.get_text(0, *GooglePlayLocators.PROVIDER) == provider

--- a/pages/GooglePlay/google_play_locators.py
+++ b/pages/GooglePlay/google_play_locators.py
@@ -1,0 +1,6 @@
+from selenium.webdriver.common.by import By
+
+
+class GooglePlayLocators:
+	APP_TITLE = (By.CSS_SELECTOR, "h1[itemprop='name'] span")
+	PROVIDER = (By.CSS_SELECTOR, "a[href^='/store/apps/dev?'] span")

--- a/test_data/google_play_data.py
+++ b/test_data/google_play_data.py
@@ -1,0 +1,6 @@
+data = {
+    "APP_URL": "https://play.google.com/store/apps/details?id=com.capital.trading",
+    "PAGE_TITLE": "Trading app by Capital.com - Apps on Google Play",
+    "APP_TITLE": "Trading app by Capital.com",
+    "PROVIDER": "Capital Com SV Investments Limited"
+}

--- a/tests/US_11_Education/US_11-03-02_Day_trading/us_11-03-02_day_trading_test.py
+++ b/tests/US_11_Education/US_11-03-02_Day_trading/us_11-03-02_day_trading_test.py
@@ -5,6 +5,7 @@ from datetime import datetime
 from pages.Elements.BlockStepTrading import BlockStepTrading
 from pages.Elements.ButtonDownloadAppStore import ButtonDownloadAppStore
 from pages.Elements.ButtonExploreWebPlatform import ButtonExploreWebPlatform
+from pages.Elements.ButtonGetItOnGooglePlay import ButtonGetItOnGooglePlay
 from pages.Elements.ButtonPractiseForFree import ButtonPractiseForFree
 from pages.Elements.ButtonStartTradingInArticle import ArticleStartTrading
 from pages.Elements.ButtonStartTradingMainBanner import MainBannerStartTrading
@@ -20,7 +21,6 @@ from pages.Elements.AssertClass import AssertClass
 
 @pytest.mark.us_11_03_02
 class TestDayTrading:
-
     page_conditions = None
 
     @allure.step("Start test of button [Log in] on Header")
@@ -86,9 +86,9 @@ class TestDayTrading:
         """
         print(f"\n{datetime.now()}   Работает obj {self} с именем TC_11.03.02_03")
         link = build_dynamic_arg(self, d, worker_id, cur_language, cur_country, cur_role, cur_login, cur_password,
-                          prob_run_tc,
-                          "11.03.02", "Educations > Menu item [Day Trading]",
-                          "03", "Testing button [Start Trading] on Main banner")
+                                 prob_run_tc,
+                                 "11.03.02", "Educations > Menu item [Day Trading]",
+                                 "03", "Testing button [Start Trading] on Main banner")
 
         page_menu = MenuSection(d, link)
         page_menu.menu_education_move_focus(d, cur_language)
@@ -118,9 +118,9 @@ class TestDayTrading:
         """
         print(f"\n{datetime.now()}   Работает obj {self} с именем TC_11.03.02_04")
         link = build_dynamic_arg(self, d, worker_id, cur_language, cur_country, cur_role, cur_login, cur_password,
-                          prob_run_tc,
-                          "11.03.02", "Educations > Menu item [Day Trading]",
-                          "04", "Testing button [Try demo] on Main banner")
+                                 prob_run_tc,
+                                 "11.03.02", "Educations > Menu item [Day Trading]",
+                                 "04", "Testing button [Try demo] on Main banner")
 
         page_menu = MenuSection(d, link)
         page_menu.menu_education_move_focus(d, cur_language)
@@ -150,9 +150,9 @@ class TestDayTrading:
         """
         print(f"\n{datetime.now()}   Работает obj {self} с именем TC_11.03.02_05")
         link = build_dynamic_arg(self, d, worker_id, cur_language, cur_country, cur_role, cur_login, cur_password,
-                          prob_run_tc,
-                          "11.03.02", "Educations > Menu item [Day Trading]",
-                          "05", "Testing button [Trade] in Most traded block")
+                                 prob_run_tc,
+                                 "11.03.02", "Educations > Menu item [Day Trading]",
+                                 "05", "Testing button [Trade] in Most traded block")
 
         page_menu = MenuSection(d, link)
         page_menu.menu_education_move_focus(d, cur_language)
@@ -183,9 +183,9 @@ class TestDayTrading:
         """
         print(f"\n{datetime.now()}   Работает obj {self} с именем TC_11.03.02_06")
         link = build_dynamic_arg(self, d, worker_id, cur_language, cur_country, cur_role, cur_login, cur_password,
-                          prob_run_tc,
-                          "11.03.02", "Educations > Menu item [Day Trading]",
-                          "06", "Testing button [Start trading] in Content block")
+                                 prob_run_tc,
+                                 "11.03.02", "Educations > Menu item [Day Trading]",
+                                 "06", "Testing button [Start trading] in Content block")
 
         page_menu = MenuSection(d, link)
         page_menu.menu_education_move_focus(d, cur_language)
@@ -215,9 +215,9 @@ class TestDayTrading:
         """
         print(f"\n{datetime.now()}   Работает obj {self} с именем TC_11.03.02_07")
         link = build_dynamic_arg(self, d, worker_id, cur_language, cur_country, cur_role, cur_login, cur_password,
-                          prob_run_tc,
-                          "11.03.02", "Educations > Menu item [Day Trading]",
-                          "07", "Testing button [Practise for free] in Content block")
+                                 prob_run_tc,
+                                 "11.03.02", "Educations > Menu item [Day Trading]",
+                                 "07", "Testing button [Practise for free] in Content block")
 
         page_menu = MenuSection(d, link)
         page_menu.menu_education_move_focus(d, cur_language)
@@ -263,6 +263,31 @@ class TestDayTrading:
         test_element = AssertClass(d, link)
         test_element.assert_app_store(d, link)
 
+    @allure.step("Start test of button [Get it on Google Play] in Block 'Sign up and trade smart today!'")
+    def test_09_button_get_it_on_google_play(
+            self, worker_id, d, cur_language, cur_country, cur_role, cur_login, cur_password, prob_run_tc):
+        """
+        Check: Button [Get it on Google Play] in Block 'Sign up and trade smart today!
+        Language: All. License: All.
+        """
+        print(f"\n{datetime.now()}   Работает obj {self} с именем TC_11.03.02_09")
+        link = build_dynamic_arg(self, d, worker_id, cur_language, cur_country, cur_role, cur_login, cur_password,
+                                 prob_run_tc,
+                                 "11.03.02", "Educations > Menu item [Day Trading]", "09",
+                                 "Test button [Get it on Google Play] in Block \"Sign up and trade smart today!\"")
+
+        page_menu = MenuSection(d, link)
+        page_menu.menu_education_move_focus(d, cur_language)
+        link = page_menu.sub_menu_day_trading_move_focus_click(d, cur_language)
+
+        test_element = ButtonGetItOnGooglePlay(d, link)
+        test_element.arrange_(link)
+        if not test_element.element_click():
+            pytest.fail("Testing element is not clicked")
+
+        test_element = AssertClass(d, link)
+        test_element.assert_google_play(d, link)
+
     @allure.step("Start test of button [Explore Web Platform] in Block 'Sign up and trade smart today!'")
     def test_10_button_explore_web_platform(
             self, worker_id, d, cur_language, cur_country, cur_role, cur_login, cur_password, prob_run_tc):
@@ -303,9 +328,9 @@ class TestDayTrading:
         """
         print(f"\n{datetime.now()}   Работает obj {self} с именем TC_11.03.02_11")
         link = build_dynamic_arg(self, d, worker_id, cur_language, cur_country, cur_role, cur_login, cur_password,
-                          prob_run_tc,
-                          "11.03.02", "Educations > Menu item [Day Trading]",
-                          "11", "Testing button [1. Create & verify your account] in Block 'Steps trading'")
+                                 prob_run_tc,
+                                 "11.03.02", "Educations > Menu item [Day Trading]",
+                                 "11", "Testing button [1. Create & verify your account] in Block 'Steps trading'")
 
         page_menu = MenuSection(d, link)
         page_menu.menu_education_move_focus(d, cur_language)


### PR DESCRIPTION
Обрати внимание, в confest добавлена опция для хрома: 
chrome_options.add_argument("--accept-lang=en")

Без этой строки локально хром открывается на русском и все заголовки в Google Play тоже на русском (проверки падают).

Сейчас тест будет падать, тк по кнопке открывается AppStore. Для проверки кода добавлял принудительное открытие Google Play. Сейчас эти строски закомментированы.

        # Следующие две строки только для проверки работоспособности asserts, тк в данный момент баг в url кнопки
        # self.link = "https://play.google.com/store/apps/details?id=com.capital.trading"
        # self.open_page()