### PR TITLE
RF add build_dynamic_arg_v2 AND RF methods for app_store, google_play, trading platform v2 - add postconditions (open page)

### DIFF
--- a/pages/AppStore/app_store.py
+++ b/pages/AppStore/app_store.py
@@ -20,8 +20,10 @@ class AppStore(BasePage):
             self.should_be_page_title_v2(data["PAGE_TITLE"])
             self.should_be_app_store_app_title(data["APP_TITLE"])
             self.should_be_app_store_specifies_provider(data["PROVIDER"])
+            self.open_page()
             assert True
         else:
+            self.open_page()
             assert False, f'Loaded page with not {data["APP_URL"]} url. Current URL is {self.browser.current_url}'
 
     @allure.step("Checking that the App Store Investmate page has opened")

--- a/pages/Capital/Trading_platform/trading_platform.py
+++ b/pages/Capital/Trading_platform/trading_platform.py
@@ -49,9 +49,12 @@ class TradingPlatform(BasePage):
         if self.current_page_url_contain_the(platform_url):
             self.should_be_page_title_v2(data["PAGE_TITLE"])
             self.should_be_platform_logo()
+            self.open_page()
             assert True, 'Page with title "Trading Platform | Capital.com" not loaded'
         else:
-            assert False, f'Loaded page {self.browser.current_url} with not {platform_url} url'
+            self.open_page()
+            print(f"Loaded page {self.browser.current_url} with not {platform_url} url")
+            assert False
 
     @allure.step("Check if the Logo element is present on the page")
     def should_be_platform_logo(self):
@@ -90,8 +93,11 @@ class TradingPlatform(BasePage):
             print(f"{datetime.now()}   BUTTON_CONTINUE =>")
             assert self.element_is_visible(TPSignupFormLocators.BUTTON_CONTINUE), \
                 f"{datetime.now()}   Problem with 'Continue' button"
+            self.open_page()
         else:
-            assert False, "'SignUp' page on the Trading Platform is not opened"
+            self.open_page()
+            print("'SignUp' page on the Trading Platform is not opened")
+            assert False
 
     @allure.step("Check that form [Login] is opened on the Trading Platform page")
     # @profile(precision=3)
@@ -123,6 +129,8 @@ class TradingPlatform(BasePage):
             print(f"{datetime.now()}   BUTTON_CONTINUE =>")
             assert self.element_is_visible(TPSignupFormLocators.BUTTON_CONTINUE), \
                 f"{datetime.now()}   Problem with 'Continue' button"
+            self.open_page()
         else:
-            pytest.xfail("'Login' page on the Trading Platform is not opened")
-            assert False, "'Login' page on the Trading Platform is not opened"
+            self.open_page()
+            print("'Login' page on the Trading Platform is not opened")
+            assert False

--- a/pages/Elements/AssertClass.py
+++ b/pages/Elements/AssertClass.py
@@ -69,7 +69,7 @@ class AssertClass(BasePage):
     @allure.step('Checking that "Trading platform" page opened - ver 2')
     def assert_trading_platform_v2(self, d, cur_link, demo=False):
         print(f"\n{datetime.now()}   3. Assert")
-        self.page_trading = TradingPlatform(d)
+        self.page_trading = TradingPlatform(d, cur_link)
         self.page_trading.should_be_trading_platform_page_v2(d, cur_link, demo)
 
 
@@ -84,7 +84,7 @@ class AssertClass(BasePage):
     @allure.step('Checking that "App Store" page opened')
     def assert_app_store(self, d, cur_link):
         print(f"\n{datetime.now()}   3. Assert")
-        self.page_app_store = AppStore(d)
+        self.page_app_store = AppStore(d, cur_link)
         self.page_app_store.should_be_app_store_page(cur_link)
         del self.page_app_store
 
@@ -98,18 +98,18 @@ class AssertClass(BasePage):
     @allure.step('Checking that "Google Play" page opened')
     def assert_google_play(self, d, cur_link):
         print(f"\n{datetime.now()}   3. Assert")
-        self.page_google_play = GooglePlay(d)
+        self.page_google_play = GooglePlay(d, cur_link)
         self.page_google_play.should_be_google_play_page(cur_link)
         del self.page_google_play
 
     @allure.step('Checking that "Sign Up" form on the Trading Platform page opened')
     def assert_signup_form_on_the_trading_platform(self, d):
         print(f"\n{datetime.now()}   3. Assert")
-        self.page_trading = TradingPlatform(d)
+        self.page_trading = TradingPlatform(d, self.link)
         self.page_trading.should_be_signup_form_on_the_trading_platform()
 
     @allure.step('Checking that "Login" form on the Trading Platform page opened')
     def assert_login_form_on_the_trading_platform(self, d):
         print(f"\n{datetime.now()}   3. Assert")
-        self.page_trading = TradingPlatform(d)
+        self.page_trading = TradingPlatform(d, self.link)
         self.page_trading.should_be_login_form_on_the_trading_platform()

--- a/pages/GooglePlay/google_play.py
+++ b/pages/GooglePlay/google_play.py
@@ -24,8 +24,10 @@ class GooglePlay(BasePage):
             self.should_be_page_title_v2(data["PAGE_TITLE"])
             self.should_be_google_play_app_title(data["APP_TITLE"])
             self.should_be_google_play_specifies_provider(data["PROVIDER"])
+            self.open_page()
             assert True
         else:
+            self.open_page()
             assert False, f'Loaded page with not {data["APP_URL"]} url'
 
     @allure.step("Checking that the Google Play app title")

--- a/tests/US_11_Education/US_11-03-02_Day_trading/us_11-03-02_day_trading_test.py
+++ b/tests/US_11_Education/US_11-03-02_Day_trading/us_11-03-02_day_trading_test.py
@@ -12,9 +12,10 @@ from pages.Elements.ButtonStartTradingMainBanner import MainBannerStartTrading
 from pages.Elements.ButtonTradeOnWidgetMostTraded import ButtonTradeOnWidgetMostTraded
 from pages.Elements.ButtonTryDemoMainBanner import MainBannerTryDemo
 from pages.Elements.HeaderButtonTrade import HeaderButtonTrade
-from pages.Elements.testing_elements_locators import ButtonTradeOnWidgetMostTradedLocators
 from pages.Menu.menu import MenuSection
-from tests.build_dynamic_arg import build_dynamic_arg
+from pages.conditions import Conditions
+from src.src import CapitalComPageSrc
+from tests.build_dynamic_arg import build_dynamic_arg_v2
 from pages.Elements.HeaderButtonLogin import HeaderButtonLogin
 from pages.Elements.AssertClass import AssertClass
 
@@ -33,10 +34,13 @@ class TestDayTrading:
         """
         print(f"\n\n{datetime.now()}   Работает obj {self} с именем TC_11.03.02_01")
 
-        link = build_dynamic_arg(self, d, worker_id, cur_language, cur_country, cur_role, cur_login, cur_password,
-                                 prob_run_tc,
-                                 "11.03.02", "Educations > Menu item [Day Trading]",
-                                 "01", "Testing button [Log In] on Header")
+        build_dynamic_arg_v2(self, d, worker_id, cur_language, cur_country, cur_role, prob_run_tc,
+                             "11.03.02", "Educations > Menu item [Day Trading]",
+                             "01", "Testing button [Log In] on Header")
+
+        page_conditions = Conditions(d, "")
+        link = page_conditions.preconditions(
+            d, CapitalComPageSrc.URL, "", cur_language, cur_country, cur_role, cur_login, cur_password)
 
         page_menu = MenuSection(d, link)
         page_menu.menu_education_move_focus(d, cur_language)
@@ -59,10 +63,13 @@ class TestDayTrading:
         Language: All. License: All.
         """
         print(f"\n\n{datetime.now()}   Работает obj {self} с именем TC_11.03.02_02")
-        link = build_dynamic_arg(self, d, worker_id, cur_language, cur_country, cur_role, cur_login, cur_password,
-                                 prob_run_tc,
-                                 "11.03.02", "Educations > Menu item [Day Trading]",
-                                 "02", "Testing button [Trade] on Header")
+        build_dynamic_arg_v2(self, d, worker_id, cur_language, cur_country, cur_role, prob_run_tc,
+                             "11.03.02", "Educations > Menu item [Day Trading]",
+                             "02", "Testing button [Trade] on Header")
+
+        page_conditions = Conditions(d, "")
+        link = page_conditions.preconditions(
+            d, CapitalComPageSrc.URL, "", cur_language, cur_country, cur_role, cur_login, cur_password)
 
         page_menu = MenuSection(d, link)
         page_menu.menu_education_move_focus(d, cur_language)
@@ -85,10 +92,13 @@ class TestDayTrading:
         Language: All. License: All.
         """
         print(f"\n{datetime.now()}   Работает obj {self} с именем TC_11.03.02_03")
-        link = build_dynamic_arg(self, d, worker_id, cur_language, cur_country, cur_role, cur_login, cur_password,
-                                 prob_run_tc,
-                                 "11.03.02", "Educations > Menu item [Day Trading]",
-                                 "03", "Testing button [Start Trading] on Main banner")
+        build_dynamic_arg_v2(self, d, worker_id, cur_language, cur_country, cur_role, prob_run_tc,
+                             "11.03.02", "Educations > Menu item [Day Trading]",
+                             "03", "Testing button [Start Trading] on Main banner")
+
+        page_conditions = Conditions(d, "")
+        link = page_conditions.preconditions(
+            d, CapitalComPageSrc.URL, "", cur_language, cur_country, cur_role, cur_login, cur_password)
 
         page_menu = MenuSection(d, link)
         page_menu.menu_education_move_focus(d, cur_language)
@@ -107,7 +117,7 @@ class TestDayTrading:
             case "Reg/NoAuth":
                 test_element.assert_login(d, link)
             case "Auth":
-                test_element.assert_trading_platform(d)
+                test_element.assert_trading_platform_v2(d, link)
 
     @allure.step("Start test of button [Try demo] on Main banner")
     def test_04_main_banner_try_demo_button(
@@ -117,10 +127,13 @@ class TestDayTrading:
         Language: All. License: All.
         """
         print(f"\n{datetime.now()}   Работает obj {self} с именем TC_11.03.02_04")
-        link = build_dynamic_arg(self, d, worker_id, cur_language, cur_country, cur_role, cur_login, cur_password,
-                                 prob_run_tc,
-                                 "11.03.02", "Educations > Menu item [Day Trading]",
-                                 "04", "Testing button [Try demo] on Main banner")
+        build_dynamic_arg_v2(self, d, worker_id, cur_language, cur_country, cur_role, prob_run_tc,
+                             "11.03.02", "Educations > Menu item [Day Trading]",
+                             "04", "Testing button [Try demo] on Main banner")
+
+        page_conditions = Conditions(d, "")
+        link = page_conditions.preconditions(
+            d, CapitalComPageSrc.URL, "", cur_language, cur_country, cur_role, cur_login, cur_password)
 
         page_menu = MenuSection(d, link)
         page_menu.menu_education_move_focus(d, cur_language)
@@ -139,7 +152,7 @@ class TestDayTrading:
             case "Reg/NoAuth":
                 test_element.assert_login(d, link)
             case "Auth":
-                test_element.assert_trading_platform(d)
+                test_element.assert_trading_platform_v2(d, link, demo=True)
 
     @allure.step("Start test of buttons [Trade] in Most traded block")
     def test_05_most_traded_trade_button(
@@ -149,30 +162,35 @@ class TestDayTrading:
         Language: All. License: All.
         """
         print(f"\n{datetime.now()}   Работает obj {self} с именем TC_11.03.02_05")
-        link = build_dynamic_arg(self, d, worker_id, cur_language, cur_country, cur_role, cur_login, cur_password,
-                                 prob_run_tc,
-                                 "11.03.02", "Educations > Menu item [Day Trading]",
-                                 "05", "Testing button [Trade] in Most traded block")
+        build_dynamic_arg_v2(self, d, worker_id, cur_language, cur_country, cur_role, prob_run_tc,
+                             "11.03.02", "Educations > Menu item [Day Trading]",
+                             "05", "Testing button [Trade] in Most traded block")
+
+        if cur_country == 'gb':
+            pytest.skip("This test is not supported on UK location")
+
+        page_conditions = Conditions(d, "")
+        link = page_conditions.preconditions(
+            d, CapitalComPageSrc.URL, "", cur_language, cur_country, cur_role, cur_login, cur_password)
 
         page_menu = MenuSection(d, link)
         page_menu.menu_education_move_focus(d, cur_language)
         link = page_menu.sub_menu_day_trading_move_focus_click(d, cur_language)
 
-        most_traded_quantity = d.find_elements(*ButtonTradeOnWidgetMostTradedLocators.MOST_TRADED)
-        for i in range(len(most_traded_quantity)):
-            test_element = ButtonTradeOnWidgetMostTraded(d, link)
-            test_element.arrange_(d, link)
-            if not test_element.element_click(i, cur_role):
+        test_element = ButtonTradeOnWidgetMostTraded(d, link)
+        test_elements_list = test_element.arrange_v2_()
+        for index, element in enumerate(test_elements_list):
+            print(f"\n{datetime.now()}   Testing element #{index + 1}")
+            if not test_element.element_click_v2(element):
                 pytest.fail("Testing element is not clicked")
-
-            test_element = AssertClass(d, link)
+            check_element = AssertClass(d, link)
             match cur_role:
                 case "NoReg":
-                    test_element.assert_signup(d, cur_language, link)
+                    check_element.assert_signup(d, cur_language, link)
                 case "Reg/NoAuth":
-                    test_element.assert_login(d, link)
+                    check_element.assert_login(d, link)
                 case "Auth":
-                    test_element.assert_trading_platform(d)
+                    check_element.assert_trading_platform_v2(d, link)
 
     @allure.step("Start test of button [Start trading] in content block")
     def test_06_start_trading_in_content_block_button(
@@ -182,10 +200,16 @@ class TestDayTrading:
         Language: All. License: All.
         """
         print(f"\n{datetime.now()}   Работает obj {self} с именем TC_11.03.02_06")
-        link = build_dynamic_arg(self, d, worker_id, cur_language, cur_country, cur_role, cur_login, cur_password,
-                                 prob_run_tc,
-                                 "11.03.02", "Educations > Menu item [Day Trading]",
-                                 "06", "Testing button [Start trading] in Content block")
+        build_dynamic_arg_v2(self, d, worker_id, cur_language, cur_country, cur_role, prob_run_tc,
+                             "11.03.02", "Educations > Menu item [Day Trading]",
+                             "06", "Testing button [Start trading] in Content block")
+
+        if cur_country == 'gb':
+            pytest.skip("This test is not supported on UK location")
+
+        page_conditions = Conditions(d, "")
+        link = page_conditions.preconditions(
+            d, CapitalComPageSrc.URL, "", cur_language, cur_country, cur_role, cur_login, cur_password)
 
         page_menu = MenuSection(d, link)
         page_menu.menu_education_move_focus(d, cur_language)
@@ -194,17 +218,7 @@ class TestDayTrading:
         test_element = ArticleStartTrading(d, link)
         test_element.arrange_(link)
 
-        if not test_element.element_click(link, cur_language, cur_role):
-            pytest.fail("Testing element is not clicked")
-
-        test_element = AssertClass(d, link)
-        match cur_role:
-            case "NoReg":
-                test_element.assert_signup(d, cur_language, link)
-            case "Reg/NoAuth":
-                test_element.assert_login(d, link)
-            case "Auth":
-                test_element.assert_trading_platform(d)
+        test_element.element_click(link, cur_language, cur_role)
 
     @allure.step("Start test of button [Practise for free] in content block")
     def test_07_practise_for_free_in_content_block_button(
@@ -214,10 +228,16 @@ class TestDayTrading:
         Language: All. License: All.
         """
         print(f"\n{datetime.now()}   Работает obj {self} с именем TC_11.03.02_07")
-        link = build_dynamic_arg(self, d, worker_id, cur_language, cur_country, cur_role, cur_login, cur_password,
-                                 prob_run_tc,
-                                 "11.03.02", "Educations > Menu item [Day Trading]",
-                                 "07", "Testing button [Practise for free] in Content block")
+        build_dynamic_arg_v2(self, d, worker_id, cur_language, cur_country, cur_role, prob_run_tc,
+                             "11.03.02", "Educations > Menu item [Day Trading]",
+                             "07", "Testing button [Practise for free] in Content block")
+
+        if cur_country == 'gb':
+            pytest.skip("This test is not supported on UK location")
+
+        page_conditions = Conditions(d, "")
+        link = page_conditions.preconditions(
+            d, CapitalComPageSrc.URL, "", cur_language, cur_country, cur_role, cur_login, cur_password)
 
         page_menu = MenuSection(d, link)
         page_menu.menu_education_move_focus(d, cur_language)
@@ -242,14 +262,17 @@ class TestDayTrading:
     def test_08_button_download_on_the_app_store(
             self, worker_id, d, cur_language, cur_country, cur_role, cur_login, cur_password, prob_run_tc):
         """
-        Check: Button [Download on the App Store] in Block 'Sign up and trade smart today!
+        Check: Button [Download on the App Store] in Block "Sign up and trade smart today!"
         Language: All. License: All.
         """
         print(f"\n{datetime.now()}   Работает obj {self} с именем TC_11.03.02_08")
-        link = build_dynamic_arg(self, d, worker_id, cur_language, cur_country, cur_role, cur_login, cur_password,
-                                 prob_run_tc,
-                                 "11.03.02", "Educations > Menu item [Day Trading]", "08",
-                                 "Test button [Download on the App Store] in Block \"Sign up and trade smart today!\"")
+        build_dynamic_arg_v2(self, d, worker_id, cur_language, cur_country, cur_role, prob_run_tc,
+                             "11.03.02", "Educations > Menu item [Day Trading]", "08",
+                             "Test button [Download on the App Store] in Block \"Sign up and trade smart today!\"")
+
+        page_conditions = Conditions(d, "")
+        link = page_conditions.preconditions(
+            d, CapitalComPageSrc.URL, "", cur_language, cur_country, cur_role, cur_login, cur_password)
 
         page_menu = MenuSection(d, link)
         page_menu.menu_education_move_focus(d, cur_language)
@@ -259,7 +282,6 @@ class TestDayTrading:
         test_element.arrange_(link)
         if not test_element.element_click():
             pytest.fail("Testing element is not clicked")
-
         test_element = AssertClass(d, link)
         test_element.assert_app_store(d, link)
 
@@ -267,14 +289,17 @@ class TestDayTrading:
     def test_09_button_get_it_on_google_play(
             self, worker_id, d, cur_language, cur_country, cur_role, cur_login, cur_password, prob_run_tc):
         """
-        Check: Button [Get it on Google Play] in Block 'Sign up and trade smart today!
+        Check: Button [Get it on Google Play] in Block "Sign up and trade smart today!"
         Language: All. License: All.
         """
         print(f"\n{datetime.now()}   Работает obj {self} с именем TC_11.03.02_09")
-        link = build_dynamic_arg(self, d, worker_id, cur_language, cur_country, cur_role, cur_login, cur_password,
-                                 prob_run_tc,
-                                 "11.03.02", "Educations > Menu item [Day Trading]", "09",
-                                 "Test button [Get it on Google Play] in Block \"Sign up and trade smart today!\"")
+        build_dynamic_arg_v2(self, d, worker_id, cur_language, cur_country, cur_role, prob_run_tc,
+                             "11.03.02", "Educations > Menu item [Day Trading]", "09",
+                             "Test button [Get it on Google Play] in Block \"Sign up and trade smart today!\"")
+
+        page_conditions = Conditions(d, "")
+        link = page_conditions.preconditions(
+            d, CapitalComPageSrc.URL, "", cur_language, cur_country, cur_role, cur_login, cur_password)
 
         page_menu = MenuSection(d, link)
         page_menu.menu_education_move_focus(d, cur_language)
@@ -292,14 +317,17 @@ class TestDayTrading:
     def test_10_button_explore_web_platform(
             self, worker_id, d, cur_language, cur_country, cur_role, cur_login, cur_password, prob_run_tc):
         """
-        Check: Button [Explore Web Platform] in Block 'Sign up and trade smart today!
+        Check: Button [Explore Web Platform] in Block "Sign up and trade smart today!"
         Language: All. License: All.
         """
         print(f"\n{datetime.now()}   Работает obj {self} с именем TC_11.03.02_10")
-        link = build_dynamic_arg(self, d, worker_id, cur_language, cur_country, cur_role, cur_login, cur_password,
-                                 prob_run_tc,
-                                 "11.03.02", "Educations > Menu item [Day Trading]", "10",
-                                 "Testing button [Explore Web Platform] in Block \"Sign up and trade smart today!\"")
+        build_dynamic_arg_v2(self, d, worker_id, cur_language, cur_country, cur_role, prob_run_tc,
+                             "11.03.02", "Educations > Menu item [Day Trading]", "10",
+                             "Testing button [Explore Web Platform] in Block \"Sign up and trade smart today!\"")
+
+        page_conditions = Conditions(d, "")
+        link = page_conditions.preconditions(
+            d, CapitalComPageSrc.URL, "", cur_language, cur_country, cur_role, cur_login, cur_password)
 
         page_menu = MenuSection(d, link)
         page_menu.menu_education_move_focus(d, cur_language)
@@ -317,7 +345,7 @@ class TestDayTrading:
             case "Reg/NoAuth":
                 test_element.assert_login_form_on_the_trading_platform(d)
             case "Auth":
-                test_element.assert_trading_platform(d)
+                test_element.assert_trading_platform_v2(d)
 
     @allure.step("Start test of button [1. Create & verify your account] in Block 'Steps trading'")
     def test_11_create_and_verify_your_account_button_in_block_steps_trading(
@@ -327,10 +355,13 @@ class TestDayTrading:
         Language: All. License: All.
         """
         print(f"\n{datetime.now()}   Работает obj {self} с именем TC_11.03.02_11")
-        link = build_dynamic_arg(self, d, worker_id, cur_language, cur_country, cur_role, cur_login, cur_password,
-                                 prob_run_tc,
-                                 "11.03.02", "Educations > Menu item [Day Trading]",
-                                 "11", "Testing button [1. Create & verify your account] in Block 'Steps trading'")
+        build_dynamic_arg_v2(self, d, worker_id, cur_language, cur_country, cur_role, prob_run_tc,
+                             "11.03.02", "Educations > Menu item [Day Trading]",
+                             "11", "Testing button [1. Create & verify your account] in Block 'Steps trading'")
+
+        page_conditions = Conditions(d, "")
+        link = page_conditions.preconditions(
+            d, CapitalComPageSrc.URL, "", cur_language, cur_country, cur_role, cur_login, cur_password)
 
         page_menu = MenuSection(d, link)
         page_menu.menu_education_move_focus(d, cur_language)
@@ -344,9 +375,7 @@ class TestDayTrading:
 
         test_element = AssertClass(d, link)
         match cur_role:
-            case "NoReg":
-                test_element.assert_signup(d, cur_language, link)
-            case "Reg/NoAuth":
+            case "NoReg", "Reg/NoAuth":
                 test_element.assert_signup(d, cur_language, link)
             case "Auth":
-                test_element.assert_trading_platform(d)
+                test_element.assert_trading_platform_v2(d, link)


### PR DESCRIPTION
Поменял в тестах build_dynamic_arg на версию 2 и докрутил немного тесты про апп стор, гугл плей, формы сайн ин, лог ин на трейдинковой платорме - сделал открытие старницы меню перед асертом, чтобы если тест упал, то новый начинался с исходной страницы меню