### PR TITLE
ADD us_11_03_07 test 01-07 AND RF assert_trading_platform_v2

### DIFF
--- a/pages/Capital/Trading_platform/trading_platform.py
+++ b/pages/Capital/Trading_platform/trading_platform.py
@@ -44,9 +44,10 @@ class TradingPlatform(BasePage):
     def should_be_trading_platform_page_v2(self, d, cur_link, demo=False):
         """Check if the page is open"""
         print(f"{datetime.now()}   Checking that the trading platform page has opened")
-        self.wait_for_change_url(cur_link, 30)
         platform_url = data["PLATFORM_DEMO_URL"] if demo else data["PLATFORM_URL"]
-        if self.current_page_url_contain_the(platform_url):
+        # print(platform_url)
+        # print(self.wait_for_change_url(platform_url, 120))
+        if self.wait_for_target_url(platform_url, 60):
             self.should_be_page_title_v2(data["PAGE_TITLE"])
             self.should_be_platform_logo()
             self.open_page()

--- a/pages/Elements/testing_elements_locators.py
+++ b/pages/Elements/testing_elements_locators.py
@@ -43,7 +43,9 @@ class BlockStepTradingLocators:
 
 
 class ButtonInBannerLocators:
-    BUTTON_IN_BANNER = (By.CSS_SELECTOR, ".grid .detail__aside .inBanner > a")
+    # BUTTON_IN_BANNER = (By.CSS_SELECTOR, ".grid .detail__aside .inBanner > a")
+    BUTTON_IN_BANNER = (By.XPATH, "//div[not(contains(@class, 'hidden'))]/div/a[contains(@data-type, 'b_vert') "
+                        "and (@href='/trading/signup')]")
     BUTTON_IN_BANNER_DEMO = (By.CSS_SELECTOR, ".grid.detail__aside.inBanner > a[data - demomode = 'true']")
 
 

--- a/pages/Menu/menu.py
+++ b/pages/Menu/menu.py
@@ -28,7 +28,8 @@ from pages.Menu.menu_locators import (
     MenuUS11DayTrading,
     MenuUS11IndicesTrading,
     MenuUS11InvestmateApp,
-    MenuUS11TrendTrading
+    MenuUS11TrendTrading,
+    MenuUS11WhatIsMargin
 )
 
 
@@ -729,4 +730,18 @@ class MenuSection(BasePage):
         print(f"\n\n{datetime.now()}   => Trend trading menu item clicked")
         time.sleep(1)
         del menu1
+        return d.current_url
+
+    @allure.step(f"{datetime.now()}.   Click 'What is a margin?' hyperlink.")
+    def sub_menu_what_is_a_margin_move_focus_click(self, d, test_language):
+        menu = d.find_elements(*MenuUS11WhatIsMargin.SUB_MENU_ALL_WHAT_IS_A_MARGIN)
+        if len(menu) > 0:
+            ActionChains(d) \
+                .move_to_element(menu[0]) \
+                .click() \
+                .perform()
+            print(f"\n\n{datetime.now()}   => 'What is a margin?' menu click")
+        else:
+            pytest.skip(f"For test language '{test_language}' "
+                        f"the page \"Education->What is a margin?\" doesn't exist on production")
         return d.current_url

--- a/pages/Menu/menu_locators.py
+++ b/pages/Menu/menu_locators.py
@@ -799,6 +799,10 @@ class MenuUS11IndicesTrading:
     SUB_MENU_RU_INDICES_TRADING = (By.CSS_SELECTOR, ".cc-header a[href$='/ru/torgovlya-indeksami-cfd']")
 
 
+class MenuUS11WhatIsMargin:
+    SUB_MENU_ALL_WHAT_IS_A_MARGIN = (By.CSS_SELECTOR, ".cc-header a[href$='/margin-trading']")
+
+
 class MenuUS11InvestmateApp:
     # SUB_MENU_AR_INVESTMATE_APP =
     # (By.CSS_SELECTOR, "div .cc-nav__wrap a[href='https://capital.com/ar/learn-trading-app']")

--- a/pages/base_page.py
+++ b/pages/base_page.py
@@ -588,6 +588,19 @@ class BasePage:
         )
 
     @HandleExcElementDecorator()
+    def wait_for_target_url(self, link, timeout=1):
+        """
+        Waiting for target url
+        Args:
+            link: the target url that we are waiting for
+            timeout (optional): specified time duration before throwing a TimeoutException. Defaults to 1.
+
+        """
+        return Wait(self.browser, timeout).until(
+            EC.url_contains(link)
+        )
+
+    @HandleExcElementDecorator()
     def is_captcha(self):
         if self.elements_are_present(*Captcha.CAPTCHA_IFRAME):
             pytest.fail("Captcha on the page")

--- a/pytest.ini
+++ b/pytest.ini
@@ -33,3 +33,4 @@ markers =
     us_11_03_01: ???
     us_11_03_02: day trading
     us_11_03_03: trend trading
+    us_11_03_07: what is a margin


### PR DESCRIPTION
- Добавлены с 1 по 7 тесты для us_11_03_07
 - Рефакторинг метода assert_trading_platform_v2: в последнее время трейдинговая платформа может открываться через промежуточный редирект, в методе я делал вейт на изменение url. сейчас это перестало работать, тк url меняется на промежуточный, но это не трейдинговая платформа. Добавил в бейс-пейдж метод - ожидания измнения url на целевой, те ждем появления url трейдинговой платформы - это позволяет пропустить промежутчный url
 - изменил твой локатор по поиску кнопки в баннере, он ищет и твои и мою кнопки, проверь у себя, пож-ста.